### PR TITLE
オンラインユーザー一覧表示とオンラインユーザーの複数削除の実装

### DIFF
--- a/dboard-backend/app/Http/Controllers/API/UserController.php
+++ b/dboard-backend/app/Http/Controllers/API/UserController.php
@@ -146,13 +146,21 @@ class UserController extends Controller
     // ログイン中ユーザーの複数選択削除
     public function bulkDelete(Request $request)
     {
-        $updatedLogoutUsers = User::where('is_online', true)->update([
-            'is_online' => false,
+        $ids = $request->input('ids');
+
+        if(empty($ids) || !is_array($ids)) {
+            return response()->json([
+                'message' => 'Invalid request',
+            ], 400);
+        }
+
+        $updatedCount = User::whereIn('id', $ids)->update([
+            'is_online' => false
         ]);
 
         return response()->json([
             'success' => true,
-            'message' => `{$updatedLogoutUsers->count()} users logged out successfully`,
+            'message' => "{$updatedCount} users logged out successfully",
         ]);
     }
 

--- a/dboard-backend/app/Models/User.php
+++ b/dboard-backend/app/Models/User.php
@@ -62,14 +62,6 @@ class User extends Authenticatable
         ]);
     }
 
-    // ログアウト状態を更新(オンラインからオフラインへ更新)
-    public function updateLogoutStatus()
-    {
-        $this->update([
-            'is_online' => false,
-        ]);
-    }
-
     // オンラインかどうか判定（最終ログインから30分以内）
     public function isOnline()
     {

--- a/dboard-frontend/src/features/users/apis/userApi.ts
+++ b/dboard-frontend/src/features/users/apis/userApi.ts
@@ -48,7 +48,7 @@ export const userApi = {
         const response = await apiClient.get(
             API_ENDPOINTS.USERS.ONLINE
         );
-        return response.data.data;
+        return response.data.onlineUsers;
     },
 
     // 複数ユーザーを一括削除

--- a/dboard-frontend/src/features/users/components/OnlineUserList.tsx
+++ b/dboard-frontend/src/features/users/components/OnlineUserList.tsx
@@ -1,0 +1,151 @@
+import { Circle } from "@mui/icons-material";
+import { Alert, Box, Typography, Button, List, ListItem, Checkbox, ListItemText, Divider, Paper } from "@mui/material";
+import { Fragment, useState } from "react";
+import styled from "styled-components";
+import { useGetOnlineUsersQuery } from "../hooks/useGetOnlineUsersQuery";
+import { useDeleteUsersMutation } from "../hooks/useDeleteUsersMutation";
+
+const Container = styled(Box)`
+    padding: 2rem;
+`;
+
+const OnlineIndicator = styled(Circle)`
+    color: #4caf50;
+    font-size: 0.8rem;
+`;
+
+const ActionContainer = styled(Box)`
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    align-items: center;
+`;
+
+export const OnlineUserList = () => {
+    const [selectedUsers, setSelectedUsers] = useState<number[]>([]);
+    const { data: users, isLoading, error, refetch } = useGetOnlineUsersQuery();
+    const deleteUsersMutation = useDeleteUsersMutation();
+    
+    const handleSelectUser = (userId: number) => {
+        setSelectedUsers(prev => 
+            prev.includes(userId)
+                ? prev.filter(id => id !== userId)
+                : [...prev, userId]
+        );
+    };
+
+    const handleSelectAll = () => {
+        if(selectedUsers.length === users?.length) {
+            setSelectedUsers([]);
+        } else {
+            setSelectedUsers(users?.map(user => user.id) || []);
+        }
+    };
+
+    const handleDeleteSelected = async() => {
+        if(window.confirm('選択したユーザーを削除してもよろしいでしょうか？')){
+            try {
+                await deleteUsersMutation.mutateAsync(selectedUsers);
+                setSelectedUsers([]); // 成功時に選択をクリア
+            } catch(error) {
+                console.error('ユーザー削除に失敗しました', error);
+            }
+        } 
+    }
+
+    if(isLoading) {
+        return <Box>Loading...</Box>;
+    }
+
+    if(error){
+        return (
+            <Alert severity="error">
+                オンラインユーザーの取得に失敗しました
+            </Alert>
+        );
+    }
+
+    if(!users || users.length === 0){
+        return (
+            <Container>
+                <Typography variant="h4" gutterBottom>
+                    オンラインユーザー
+                </Typography>
+                <Alert severity="error">
+                    現在オンラインのユーザーはいません
+                </Alert>
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            <Typography variant="h4" gutterBottom>
+                オンラインユーザー ({users.length})
+            </Typography>
+
+            <ActionContainer>
+                <Button
+                    variant="outlined"
+                    onClick={handleSelectAll}
+                >
+                    {selectedUsers.length === users.length ? '全選択解除' : '全選択'}
+                </Button>
+
+                {selectedUsers.length > 0 && (
+                    <Button
+                        variant="contained"
+                        color="error"
+                        onClick={handleDeleteSelected}
+                        loading={deleteUsersMutation.isPending}
+                    >
+                        選択したユーザーを削除 {selectedUsers.length}
+                    </Button>
+                )}
+
+                <Button
+                    variant="outlined"
+                    onClick={() => refetch()}
+                >
+                    更新
+                </Button>
+            </ActionContainer>
+
+            <Paper elevation={3}>
+                <List>
+                    {users.map((user, index) => (
+                        <Fragment key={user.id}>
+                            <ListItem>
+                                <Checkbox
+                                    checked={selectedUsers.includes(user.id)}
+                                    onChange={() => handleSelectUser(user.id)}
+                                />
+                                <ListItemText
+                                    primary={
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                            {user.name}
+                                            <OnlineIndicator />
+                                        </Box>
+                                    }
+                                    secondary={
+                                        <Box>
+                                            <Typography variant="body2" color="textSecondary">
+                                                {user.email}
+                                            </Typography>
+                                            {user.last_login_at && (
+                                                <Typography variant="caption" color="textSecondary">
+                                                    最終ログイン: {new Date(user.last_login_at).toLocaleDateString('ja-JP')}
+                                                </Typography>
+                                            )}
+                                        </Box>
+                                    }
+                                />
+                            </ListItem>
+                            {index < users.length - 1 && <Divider />}
+                        </Fragment>
+                    ))}
+                </List>
+            </Paper>
+        </Container>
+    );
+}

--- a/dboard-frontend/src/features/users/hooks/useDeleteUsersMutation.ts
+++ b/dboard-frontend/src/features/users/hooks/useDeleteUsersMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { userApi } from "../apis/userApi";
+
+export const useDeleteUsersMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (ids: number[]) => userApi.bulkDeleteUsers(ids),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['users'] });
+            queryClient.invalidateQueries({ queryKey: ['online-users'] });
+        },
+    });
+}

--- a/dboard-frontend/src/features/users/hooks/useGetOnlineUsersQuery.ts
+++ b/dboard-frontend/src/features/users/hooks/useGetOnlineUsersQuery.ts
@@ -6,6 +6,5 @@ export const useGetOnlineUsersQuery = () => {
         queryKey: ['online-users'],
         queryFn: () => userApi.getOnlineUsers(),
         refetchInterval: 30000,
-        staleTime: 1000 * 15,
     });
 }

--- a/dboard-frontend/src/features/users/pages/OnlineUserPage.tsx
+++ b/dboard-frontend/src/features/users/pages/OnlineUserPage.tsx
@@ -1,0 +1,5 @@
+import { OnlineUserList } from "../components/OnlineUserList"
+
+export const OnlineUserPage = () => {
+    return <OnlineUserList />;
+}

--- a/dboard-frontend/src/routers/AppRouter.tsx
+++ b/dboard-frontend/src/routers/AppRouter.tsx
@@ -7,6 +7,7 @@ import { UserListPage } from "../features/users/pages/UserListPage";
 import { UserDetailPage } from "../features/users/pages/UserDetailPage";
 import { CreateUserPage } from "../features/users/pages/CreateUserPage";
 import { UpdateUserPage } from "../features/users/pages/UpdateUserPage";
+import { OnlineUserPage } from "../features/users/pages/OnlineUserPage";
 
 export const AppRouter = () => {
 
@@ -53,6 +54,14 @@ export const AppRouter = () => {
                         </Layout>
                     </ProtectedRoute>
                 }
+                />
+                <Route path="/online-users" element={
+                    <ProtectedRoute>
+                        <Layout>
+                            <OnlineUserPage />
+                        </Layout>
+                    </ProtectedRoute>
+                } 
                 />
             </Routes>
         </BrowserRouter>


### PR DESCRIPTION
## 背景
- 課題として挙がっていた「オンラインユーザーを複数削除できるようにしたい」という要求を満たすために実施。

## やったこと
- オンラインユーザーの一覧表示
- 選択したオンラインユーザーの削除

##  動作確認
- オンラインユーザーを削除する前
<img width="542" height="470" alt="スクリーンショット 2025-10-05 16 02 29" src="https://github.com/user-attachments/assets/5db1af0a-2f9a-4c42-b6f8-cee6738aa126" />


- オンラインユーザーを削除した後
<img width="547" height="288" alt="スクリーンショット 2025-10-05 16 02 40" src="https://github.com/user-attachments/assets/771de19f-4b8d-49c0-abf5-48c78a5624af" />
